### PR TITLE
Added PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,10 @@
+- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
+  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
+
+## Summary
+
+What did you add, change, or remove, concretely?
+
+## Motivation
+
+What bug or problem does this solve?

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,11 @@
+- \[ ] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
+- \[ ] I've added the `release` label to this PR
+
+## Changes
+
+Paste in the respective changes from `CHANGELOG.md`
+
+## Actions after merge
+
+Follow the step-by-step guide found here:
+<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>


### PR DESCRIPTION
## Summary

- Added PR templates to .github/PULL_REQUEST_TEMPLATES dir, copied from wharf-web

## Motivation

Use the same PR templates as in the other repos
