### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.0.0 (WIP)
+## v1.0.1 (2022-01-25)
+
+- Security: Changed version of node-fetch from 2.6.5 to 3.2.0 for
+  [CVE-2022-0235](https://nvd.nist.gov/vuln/detail/CVE-2022-0235). (#3)
+
+## v1.0.0 (2021-11-05)
 
 - Initial release. (#2)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

PR #3 was created by dependabot, and I forgot to update its PR with a change to the CHANGELOG.md, therefore I'm updating it in this PR.

Also, seems to have forgotten to update the WIP tag in the v1.0.0 release.

## Changes

- Security: Changed version of node-fetch from 2.6.5 to 3.2.0 for [CVE-2022-0235](https://nvd.nist.gov/vuln/detail/CVE-2022-0235). (#3)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
