### PR TITLE
Change package to ES module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 ## v2.0.0 (WIP)
 
 - BREAKING: Changed package to ES module to stay compatible with node-fetch.
+  This drops support for usage by CommonJS modules. (#6)
+
+  If importing this package in a script file, a quick fix is to rename the file
+  from `myscript.js` to `myscript.mjs`, and then run `node myscript.mjs`.
 
 ## v1.0.1 (2022-01-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.0.0 (WIP)
+
+- BREAKING: Changed package to ES module to stay compatible with node-fetch.
+
 ## v1.0.1 (2022-01-25)
 
 - Security: Changed version of node-fetch from 2.6.5 to 3.2.0 for

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ license text is missing from the `node_modules` folder.
 1. First install:
 
    ```console
-   $ npm install --save-dev @iver-wharf/wharf-collect-licenses
+   $ npm install --save-dev @iver-wharf/wharf-collect-licenses@2
    ```
 
 2. Then write a simple JavaScript file to use it:
 
    ```js
-   // collect-licenses.js
+   // collect-licenses.mjs
 
    const { collectLicenses } = require('@iver-wharf/wharf-collect-licenses');
 
@@ -45,7 +45,7 @@ license text is missing from the `node_modules` folder.
 3. Then run it via Node:
 
    ```console
-   $ node collect-licenses.js
+   $ node collect-licenses.mjs
 
    Checking packages in package: /home/me/code/wharf/wharf-web
    Using license overrides from: /home/me/code/wharf/wharf-web/deploy/collect-licenses/licenses_override

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iver-wharf/wharf-collect-licenses",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint-ts": "eslint .",
     "lint-md": "remark ."
   },
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/collect.ts
+++ b/src/collect.ts
@@ -2,8 +2,8 @@ import checker from 'license-checker';
 import { exit } from 'process';
 import fs from 'fs';
 import path from 'path';
-import { CachedFetch } from './cached-fetch';
-import { Options, LicensedPackageData } from './types';
+import { CachedFetch } from './cached-fetch.js';
+import { Options, LicensedPackageData } from './types.js';
 
 const cachedFetch = new CachedFetch();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './collect';
+export * from './collect.js';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,3 @@
-import { collectLicenses } from './collect';
+import { collectLicenses } from './collect.js';
 
 collectLicenses();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 // Used in {@link} comment
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { collectLicenses } from './collect';
+import { collectLicenses } from './collect.js';
 
 export interface ErrorOnPackage {
   name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "es6",
     "esModuleInterop": true,
     "target": "es6",
     "moduleResolution": "node",
@@ -9,6 +9,6 @@
     "declaration": true
   },
   "lib": [
-    "es2015"
+    "es6"
   ]
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added ES module support

## Motivation

node-fetch v3 requires that the package be an ES module. I've marked version 1.0.1 as deprecated on npmjs.com as it's unusable.

This PR changes this package to be an ES module.

This drops support for CommonJS modules, which is why I did a major version bump.
