### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.0 (WIP)
+## v2.0.0 (2022-01-28)
 
 - BREAKING: Changed package to ES module to stay compatible with node-fetch.
   This drops support for usage by CommonJS modules. (#6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.0 (2022-01-28)
+## v2.0.0 (2022-02-07)
 
 - BREAKING: Changed package to ES module to stay compatible with node-fetch.
   This drops support for usage by CommonJS modules. (#6)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iver-wharf/wharf-collect-licenses",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iver-wharf/wharf-collect-licenses",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Collects licenses from node_modules and GitHub and outputs license texts and metadata in JSON format",
   "scripts": {
     "build": "tsc --build tsconfig.json",


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- BREAKING: Changed package to ES module to stay compatible with node-fetch. This drops support for usage by CommonJS modules. (#6)

  If importing this package in a script file, a quick fix is to rename the file from `myscript.js` to `myscript.mjs`, and then run `node myscript.mjs`.

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
