### PR TITLE
Moved linting to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: dist deps \
+	lint lint-md lint-ts \
+	lint-fix lint-fix-md lint-fix-ts
+
+dist:
+	npm run build
+
+deps:
+	npm install
+
+lint: lint-md lint-ts
+lint-fix: lint-fix-md lint-fix-ts
+
+lint-md:
+	npx remark . .github
+
+lint-fix-md:
+	npx remark . .github -o
+
+lint-ts:
+	npx eslint .
+
+lint-fix-ts:
+	npx eslint --fix .

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The resulting JSON file contains the following format:
 ## Linting
 
 ```sh
+make deps # download linting dependencies
+
 make lint
 
 make lint-ts # only lint TypeScript code

--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ The resulting JSON file contains the following format:
 ]
 ```
 
+## Linting
+
+```sh
+make lint
+
+make lint-ts # only lint TypeScript code
+make lint-md # only lint Markdown files
+```
+
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+make lint-fix-ts # only lint and fix TypeScript files
+make lint-fix-md # only lint and fix Markdown files
+```
+
 ---
 
 Maintained by [Iver](https://www.iver.com/en).

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.json",
     "start": "tsc --build tsconfig.json && node -r source-map-support/register dist/main.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint . && remark .",
-    "lint-ts": "eslint .",
-    "lint-md": "remark ."
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Added targets to `Makefile` for linting
- Removed linting from NPM scripts in `package.json`
- Simplified linting docs

## Motivation

Moves focus from relying on NPM for all linting stuff over to Makefile.

Based on https://github.com/iver-wharf/wharf-cmd/pull/31
